### PR TITLE
unit test for child chain block.py & server.py

### DIFF
--- a/plasma_cash/child_chain/block.py
+++ b/plasma_cash/child_chain/block.py
@@ -1,6 +1,6 @@
 import rlp
 from ethereum import utils
-from rlp.sedes import CountableList, binary
+from rlp.sedes import CountableList
 
 from plasma_cash.utils.merkle.sparse_merkle_tree import SparseMerkleTree
 
@@ -11,10 +11,9 @@ class Block(rlp.Serializable):
 
     fields = [
         ('transaction_set', CountableList(Transaction)),
-        ('sig', binary),
     ]
 
-    def __init__(self, transaction_set=None, sig=b'\x00' * 65):
+    def __init__(self, transaction_set=None):
         # There's a weird bug that when using
         # def __init__(self, transaction_set=[],...)
         # `transaction_set` would sometimes NOT be an empty list
@@ -25,12 +24,11 @@ class Block(rlp.Serializable):
             transaction_set = []
 
         self.transaction_set = transaction_set
-        self.sig = sig
         self.merkle = None
 
     @property
     def hash(self):
-        return utils.sha3(rlp.encode(self, UnsignedBlock))
+        return utils.sha3(rlp.encode(self))
 
     def merklize_transaction_set(self):
         hashed_transaction_dict = {tx.uid: tx.merkle_hash for tx in self.transaction_set}
@@ -45,6 +43,3 @@ class Block(rlp.Serializable):
             if tx.uid == uid:
                 return tx
         return None
-
-
-UnsignedBlock = Block.exclude(['sig'])

--- a/plasma_cash/child_chain/server.py
+++ b/plasma_cash/child_chain/server.py
@@ -4,25 +4,27 @@ from plasma_cash.child_chain.child_chain import ChildChain
 from plasma_cash.config import plasma_config
 from plasma_cash.root_chain.deployer import Deployer
 
-authority = plasma_config['AUTHORITY']
-root_chain = Deployer().get_contract('RootChain/RootChain.sol')
-child_chain = ChildChain(authority, root_chain)
-
 app = Flask(__name__)
+
+
+def get_child_chain():
+    authority = plasma_config['AUTHORITY']
+    root_chain = Deployer().get_contract('RootChain/RootChain.sol')
+    return ChildChain(authority, root_chain)
 
 
 @app.route('/block', methods=['GET'])
 def get_current_block():
-    return child_chain.get_current_block()
+    return get_child_chain().get_current_block()
 
 
 @app.route('/submit_block', methods=['POST'])
 def submit_block():
     sig = request.form['sig']
-    return child_chain.submit_block(sig)
+    return get_child_chain().submit_block(sig)
 
 
 @app.route('/send_tx', methods=['POST'])
 def send_tx():
     tx = request.form['tx']
-    return child_chain.apply_transaction(tx)
+    return get_child_chain().apply_transaction(tx)

--- a/unit_tests/child_chain/test_block.py
+++ b/unit_tests/child_chain/test_block.py
@@ -1,0 +1,55 @@
+import pytest
+
+from plasma_cash.child_chain.block import Block
+from plasma_cash.child_chain.transaction import Transaction
+
+
+class TestBlock(object):
+    DUMMY_TX_OWNER = b'\x8cT\xa4\xa0\x17\x9f$\x80\x1fI\xf92-\xab<\x87\xeb\x19L\x9b'
+    UID = 1
+
+    @pytest.fixture(scope='function')
+    def block(self):
+        tx = Transaction(
+            prev_block=0,
+            uid=self.UID,
+            amount=10,
+            new_owner=self.DUMMY_TX_OWNER
+        )
+        return Block(transaction_set=[tx])
+
+    def test_constructor(self):
+        DUMMY_TX_SET = ['tx set']
+        block = Block(transaction_set=DUMMY_TX_SET)
+        assert block.transaction_set == DUMMY_TX_SET
+        assert block.merkle is None
+
+    def test_constructor_with_default_param(self):
+        block = Block()
+        assert block.transaction_set == []
+        assert block.merkle is None
+
+    def test_hash(self, block):
+        EXPECTED_HASH = (b'~\xd9\x979L.2\xb1\xa3\x1b\x81\x1e`\xa6\xddg*\xf3D\x92'
+                         b'\xb6\x0f\x04\xe7f\x05\x99\x1fr\x9a\xbe\x97')
+        assert block.hash == EXPECTED_HASH
+
+    def test_merklize_transaction_set(self, block):
+        EXPECTED_MERKLE_ROOT = (b'\x8b\x9d\xc6l\xe8\x1a#\xb6y\xfb\xb5\xc4\x98'
+                                b'\xa7\xaa\xc1\x04\xa3>\xb3\xc0p8\xa8%\xb1\xa1F2\xa3w\xa6')
+        assert block.merklize_transaction_set() == EXPECTED_MERKLE_ROOT
+
+    def test_add_tx(self, block):
+        dummy_tx = Transaction(prev_block=0, uid=2, amount=10,
+                               new_owner=self.DUMMY_TX_OWNER)
+        block.add_tx(dummy_tx)
+        assert len(block.transaction_set) == 2
+        assert dummy_tx in block.transaction_set
+
+    def test_get_tx_by_uid_tx_exists(self, block):
+        tx = block.get_tx_by_uid(self.UID)
+        assert tx.uid == self.UID
+
+    def test_get_tx_by_uid_none(self, block):
+        NON_EXIST_UID = 91923
+        assert block.get_tx_by_uid(NON_EXIST_UID) is None

--- a/unit_tests/child_chain/test_child_chain.py
+++ b/unit_tests/child_chain/test_child_chain.py
@@ -4,13 +4,13 @@ from ethereum import utils as eth_utils
 from mockito import any, mock, verify, when
 
 from plasma_cash.child_chain.block import Block
-from plasma_cash.child_chain.transaction import Transaction
 from plasma_cash.child_chain.child_chain import ChildChain
 from plasma_cash.child_chain.exceptions import (InvalidBlockSignatureException,
                                                 InvalidTxSignatureException,
                                                 PreviousTxNotFoundException,
                                                 TxAlreadySpentException,
                                                 TxAmountMismatchException)
+from plasma_cash.child_chain.transaction import Transaction
 from unit_tests.unstub_mixin import UnstubMixin
 
 

--- a/unit_tests/child_chain/test_server.py
+++ b/unit_tests/child_chain/test_server.py
@@ -1,0 +1,48 @@
+import pytest
+from mockito import mock, when
+
+from plasma_cash.child_chain.server import app
+from unit_tests.unstub_mixin import UnstubMixin
+
+
+class TestServer(UnstubMixin):
+    CHILD_CHAIN = mock()
+
+    @pytest.fixture(scope='function')
+    def client(self):
+        app.config['TESTING'] = True
+        return app.test_client()
+
+    def test_get_current_block(self, client):
+        (when('plasma_cash.child_chain.server')
+            .get_child_chain().thenReturn(self.CHILD_CHAIN))
+
+        DUMMY_BLOCK = 'block'
+        when(self.CHILD_CHAIN).get_current_block().thenReturn(DUMMY_BLOCK)
+
+        resp = client.get('block')
+        assert resp.data == DUMMY_BLOCK.encode()
+
+    def test_submit_block(self, client):
+        (when('plasma_cash.child_chain.server')
+            .get_child_chain().thenReturn(self.CHILD_CHAIN))
+
+        SIG = 'sig'
+        DUMMY_MERKLE_HASH = 'merkle hash'
+        (when(self.CHILD_CHAIN)
+            .submit_block(SIG).thenReturn(DUMMY_MERKLE_HASH))
+
+        resp = client.post('submit_block', data={'sig': SIG})
+        assert resp.data == DUMMY_MERKLE_HASH.encode()
+
+    def test_send_tx(self, client):
+        (when('plasma_cash.child_chain.server')
+            .get_child_chain().thenReturn(self.CHILD_CHAIN))
+
+        DUMMY_TX = 'tx'
+        DUMMY_TX_HASH = 'tx hash'
+        (when(self.CHILD_CHAIN)
+            .apply_transaction(DUMMY_TX).thenReturn(DUMMY_TX_HASH))
+
+        resp = client.post('send_tx', data={'tx': DUMMY_TX})
+        assert resp.data == DUMMY_TX_HASH.encode()


### PR DESCRIPTION
fix #8 
fix #9 
- add unit tests for block.py
- add unit tests for server.py
- remove `sig` in Block
- in server.py use `get_child_chain` function for easier mock