### PR TITLE
Upgrade flask to 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ python deployment.py
 
 Run child chain:
 ```
-FLASK_APP=plasma_cash/child_chain/server.py flask run --port=8546
+FLASK_APP=plasma_cash/child_chain FLASK_ENV=develment flask run --port=8546
 ```
 
 Client:

--- a/plasma_cash/child_chain/__init__.py
+++ b/plasma_cash/child_chain/__init__.py
@@ -1,0 +1,15 @@
+from flask import Flask
+
+from plasma_cash.dependency_config import container
+
+
+def create_app():
+    app = Flask(__name__)
+
+    # Create a child chain instance when creating a Flask app.
+    container.get_child_chain()
+
+    from . import server
+    app.register_blueprint(server.bp)
+
+    return app

--- a/plasma_cash/child_chain/server.py
+++ b/plasma_cash/child_chain/server.py
@@ -1,22 +1,22 @@
-from flask import Flask, request
+from flask import Blueprint, request
 
 from plasma_cash.dependency_config import container
 
-app = Flask(__name__)
+bp = Blueprint('api', __name__)
 
 
-@app.route('/block', methods=['GET'])
+@bp.route('/block', methods=['GET'])
 def get_current_block():
     return container.get_child_chain().get_current_block()
 
 
-@app.route('/submit_block', methods=['POST'])
+@bp.route('/submit_block', methods=['POST'])
 def submit_block():
     sig = request.form['sig']
     return container.get_child_chain().submit_block(sig)
 
 
-@app.route('/send_tx', methods=['POST'])
+@bp.route('/send_tx', methods=['POST'])
 def send_tx():
     tx = request.form['tx']
     return container.get_child_chain().apply_transaction(tx)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 py-solc==2.1.0
 web3==3.16.5
-Flask==0.12.2
+Flask==1.0.2
 requests==2.18.4
 rlp==0.6.0
 ethereum==2.3.1


### PR DESCRIPTION
Here is a small problem in the previous code. Originally, we set up a global variable named `child_chain` to initialize a ChildChain instance right after creating a flask app in server.py. However, in this design, we found it hard to get the flask app without creating a child chain instance when testing server.py.

Therefore, we created a class `DependencyContainer` to handle the child chain instance. If the API wants a child chain instance, it just gets it from the container. However, in this design, we don't initialize the child chain until one of the APIs is called. This will cause deposit event listener not to be registered even the server is already online.

The workaround here is to use `create_app()` function provided in flask 1.0 to create a flask app. And we initialize a child chain instance inside the function.