### PR TITLE
unit tests for client/ and utils.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ FLASK_APP=plasma_cash/child_chain FLASK_ENV=develment flask run --port=8546
 Client:
 ```
 python
->>> from plasma_cash.client.client import Client
->>> c = Client()
->>> c.deposit(100, '0xb83e232458a092696be9717045d9a605fb0fec2b')
+>>> from plasma_cash.dependency_config import container
+>>> c = container.get_client()
+>>> c.deposit(100, '0xb83e232458a092696be9717045d9a605fb0fec2b', '0x0000000000000000000000000000000000000000')
 >>> c.submit_block('0xa18969817c2cefadf52b93eb20f917dce760ce13b2ac9025e0361ad1e7a1d448')
 >>> c.send_transaction(1, 1693390459388381052156419331572168595237271043726428428352746834777341368960, 100, '0x08d92dca9038ea9433254996a2d4f08d43be8227', '0xe4807cf08191b310fe1821e6e5397727ee6bc694e92e25115eca40114e3a4e6b')
 ```

--- a/plasma_cash/child_chain/__init__.py
+++ b/plasma_cash/child_chain/__init__.py
@@ -1,5 +1,4 @@
 from flask import Flask
-
 from plasma_cash.dependency_config import container
 
 

--- a/plasma_cash/client/child_chain_client.py
+++ b/plasma_cash/client/child_chain_client.py
@@ -3,7 +3,7 @@ import requests
 from .exceptions import RequestFailedException
 
 
-class ChildChainService(object):
+class ChildChainClient(object):
 
     def __init__(self, base_url, verify=False, timeout=5):
         self.base_url = base_url

--- a/plasma_cash/client/client.py
+++ b/plasma_cash/client/client.py
@@ -3,21 +3,16 @@ from ethereum import utils
 
 from plasma_cash.child_chain.block import Block
 from plasma_cash.child_chain.transaction import Transaction
-from plasma_cash.root_chain.deployer import Deployer
 from plasma_cash.utils.utils import sign
-
-from .child_chain_service import ChildChainService
 
 
 class Client(object):
 
-    def __init__(self,
-                 root_chain=Deployer().get_contract('RootChain/RootChain.sol'),
-                 child_chain=ChildChainService('http://localhost:8546')):
+    def __init__(self, root_chain, child_chain):
         self.root_chain = root_chain
         self.child_chain = child_chain
 
-    def deposit(self, amount, depositor, currency='0x0000000000000000000000000000000000000000'):
+    def deposit(self, amount, depositor, currency):
         self.root_chain.transact({'from': depositor}).deposit(currency, amount)
 
     def submit_block(self, key):

--- a/plasma_cash/dependency_config.py
+++ b/plasma_cash/dependency_config.py
@@ -1,18 +1,40 @@
 from plasma_cash.child_chain.child_chain import ChildChain
+from plasma_cash.client.child_chain_client import ChildChainClient
+from plasma_cash.client.client import Client
 from plasma_cash.config import plasma_config
 from plasma_cash.root_chain.deployer import Deployer
 
 
 class DependencyContainer(object):
     def __init__(self):
+        self._root_chain = None
         self._child_chain = None
+        self._child_chain_client = None
+        self._client = None
+
+    def get_root_chain(self):
+        if self._root_chain is None:
+            self._root_chain = Deployer().get_contract('RootChain/RootChain.sol')
+        return self._root_chain
 
     def get_child_chain(self):
         if self._child_chain is None:
             authority = plasma_config['AUTHORITY']
-            root_chain = Deployer().get_contract('RootChain/RootChain.sol')
+            root_chain = self.get_root_chain()
             self._child_chain = ChildChain(authority, root_chain)
         return self._child_chain
+
+    def get_child_chain_client(self):
+        if self._child_chain_client is None:
+            self._child_chain_client = ChildChainClient('http://localhost:8546')
+        return self._child_chain_client
+
+    def get_client(self):
+        if self._client is None:
+            root_chain = self.get_root_chain()
+            child_chain = self.get_child_chain_client()
+            self._client = Client(root_chain, child_chain)
+        return self._client
 
 
 container = DependencyContainer()

--- a/unit_tests/child_chain/test_server.py
+++ b/unit_tests/child_chain/test_server.py
@@ -1,7 +1,7 @@
 import pytest
 from mockito import mock, when
 
-from plasma_cash.child_chain.__init__ import create_app
+from plasma_cash.child_chain import create_app
 from unit_tests.unstub_mixin import UnstubMixin
 
 
@@ -10,7 +10,7 @@ class TestServer(UnstubMixin):
 
     @pytest.fixture(scope='function')
     def app(self):
-        (when('plasma_cash.child_chain.__init__.container')
+        (when('plasma_cash.child_chain.container')
             .get_child_chain().thenReturn(self.CHILD_CHAIN))
         app = create_app()
         app.config['TESTING'] = True

--- a/unit_tests/child_chain/test_transaction.py
+++ b/unit_tests/child_chain/test_transaction.py
@@ -1,5 +1,5 @@
 import pytest
-from mockito import patch
+from mockito import when
 
 from plasma_cash.child_chain.transaction import Transaction
 from unit_tests.unstub_mixin import UnstubMixin
@@ -59,15 +59,18 @@ class TestTransaction(UnstubMixin):
                        b'\x98\x1e\xcb\t\xcb\x08\n\xd1\r6\x85\x0b\x19')
         assert tx.merkle_hash == MERKLE_HASH
 
+    def test_sender(self, tx):
+        DUMMY_SENDER = 'sender'
+        (when('plasma_cash.child_chain.transaction')
+            .get_sender(tx.hash, tx.sig)
+            .thenReturn(DUMMY_SENDER))
+
+        assert tx.sender == DUMMY_SENDER
+
     def test_sign(self, tx):
         SIGNATURE = 'signature'
         DUMMY_KEY = 'key'
-
-        def sign_func(hash, key):
-            if hash == tx.hash and key == DUMMY_KEY:
-                return SIGNATURE
-            raise Exception('unexpected input to patch sign_func')
-
-        patch('plasma_cash.child_chain.transaction.sign', sign_func)
+        (when('plasma_cash.child_chain.transaction')
+            .sign(tx.hash, DUMMY_KEY).thenReturn(SIGNATURE))
         tx.sign(DUMMY_KEY)
         assert tx.sig == SIGNATURE

--- a/unit_tests/client/test_child_chain_client.py
+++ b/unit_tests/client/test_child_chain_client.py
@@ -1,0 +1,115 @@
+import pytest
+from mockito import mock, verify, when
+
+from plasma_cash.client.child_chain_client import ChildChainClient
+from plasma_cash.client.exceptions import RequestFailedException
+from unit_tests.unstub_mixin import UnstubMixin
+
+
+class TestChildChainClient(UnstubMixin):
+    BASE_URL = 'https://dummy-plasma-cash'
+
+    @pytest.fixture(scope='function')
+    def client(self):
+        return ChildChainClient(self.BASE_URL)
+
+    def test_constructor(self):
+        DUMMY_BASE_URL = 'base url'
+        DUMMY_VERIFY = True
+        DUMMY_TIME_OUT = 100
+
+        c = ChildChainClient(DUMMY_BASE_URL, DUMMY_VERIFY, DUMMY_TIME_OUT)
+        assert c.base_url == DUMMY_BASE_URL
+        assert c.verify == DUMMY_VERIFY
+        assert c.timeout == DUMMY_TIME_OUT
+
+    def test_request_success(self, client):
+        DUMMY_END_POINT = '/end-point'
+        DUMMY_METHOD = 'post'
+        DUMMY_PARAMS = 'parmas'
+        DUMMY_DATA = {'data': 'dummy'}
+        DUMMY_HEADERS = 'headers'
+
+        URL = self.BASE_URL + DUMMY_END_POINT
+
+        MOCK_RESPONSE = mock({'ok': True})
+
+        (when('plasma_cash.client.child_chain_client.requests')
+            .request(
+                method=DUMMY_METHOD,
+                url=URL,
+                params=DUMMY_PARAMS,
+                data=DUMMY_DATA,
+                headers=DUMMY_HEADERS,
+                verify=client.verify,
+                timeout=client.timeout
+            ).thenReturn(MOCK_RESPONSE))
+
+        resp = client.request(
+            DUMMY_END_POINT,
+            DUMMY_METHOD,
+            DUMMY_PARAMS,
+            DUMMY_DATA,
+            DUMMY_HEADERS
+        )
+
+        assert resp == MOCK_RESPONSE
+
+    def test_request_failed(self, client):
+        DUMMY_END_POINT = '/end-point'
+        DUMMY_METHOD = 'post'
+        DUMMY_PARAMS = 'parmas'
+        DUMMY_DATA = {'data': 'dummy'}
+        DUMMY_HEADERS = 'headers'
+
+        URL = self.BASE_URL + DUMMY_END_POINT
+
+        MOCK_RESPONSE = mock({'ok': False})
+
+        (when('plasma_cash.client.child_chain_client.requests')
+            .request(
+                method=DUMMY_METHOD,
+                url=URL,
+                params=DUMMY_PARAMS,
+                data=DUMMY_DATA,
+                headers=DUMMY_HEADERS,
+                verify=client.verify,
+                timeout=client.timeout
+            ).thenReturn(MOCK_RESPONSE))
+
+        with pytest.raises(RequestFailedException):
+            client.request(
+                DUMMY_END_POINT,
+                DUMMY_METHOD,
+                DUMMY_PARAMS,
+                DUMMY_DATA,
+                DUMMY_HEADERS
+            )
+
+    def test_get_current_block(self, client):
+        RESP_TEXT = 'response text'
+        MOCK_RESP = mock({'text': RESP_TEXT})
+
+        when(client).request('/block', 'GET').thenReturn(MOCK_RESP)
+        resp = client.get_current_block()
+        assert resp == RESP_TEXT
+
+    def test_submit_block(self, client):
+        DUMMY_SIG = 'sig'
+        when(client).request(any, any, data=any).thenReturn(None)
+        client.submit_block(DUMMY_SIG)
+        verify(client).request(
+            '/submit_block',
+            'POST',
+            data={'sig': DUMMY_SIG}
+        )
+
+    def test_send_transaction(self, client):
+        DUMMY_TX = 'tx'
+        when(client).request(any, any, data=any).thenReturn(None)
+        client.send_transaction(DUMMY_TX)
+        verify(client).request(
+            '/send_tx',
+            'POST',
+            data={'tx': DUMMY_TX}
+        )

--- a/unit_tests/client/test_client.py
+++ b/unit_tests/client/test_client.py
@@ -1,0 +1,106 @@
+import pytest
+from mockito import any, mock, verify, when
+
+from plasma_cash.child_chain.block import Block
+from plasma_cash.client.client import Client
+from unit_tests.unstub_mixin import UnstubMixin
+
+
+class TestClient(UnstubMixin):
+
+    @pytest.fixture(scope='function')
+    def root_chain(self):
+        return mock()
+
+    @pytest.fixture(scope='function')
+    def child_chain(self):
+        return mock()
+
+    @pytest.fixture(scope='function')
+    def client(self, root_chain, child_chain):
+        return Client(root_chain, child_chain)
+
+    def test_constructor(self):
+        DUMMY_ROOT_CHAIN = 'root chain'
+        DUMMY_CHILD_CHAIN = 'child chain'
+        c = Client(DUMMY_ROOT_CHAIN, DUMMY_CHILD_CHAIN)
+        assert c.root_chain == DUMMY_ROOT_CHAIN
+        assert c.child_chain == DUMMY_CHILD_CHAIN
+
+    def test_deposit(self, client, root_chain):
+        MOCK_TRANSACT = mock()
+        DUMMY_AMOUNT = 1
+        DUMMY_DEPOSITOR = 'dummy depositor'
+        DUMMY_CURRENCY = 'dummy currency'
+
+        when(root_chain).transact({'from': DUMMY_DEPOSITOR}).thenReturn(MOCK_TRANSACT)
+
+        client.deposit(DUMMY_AMOUNT, DUMMY_DEPOSITOR, DUMMY_CURRENCY)
+
+        verify(MOCK_TRANSACT).deposit(DUMMY_CURRENCY, DUMMY_AMOUNT)
+
+    def test_submit_block(self, client, child_chain):
+        MOCK_HASH = 'mock hash'
+        MOCK_BLOCK = mock({'hash': MOCK_HASH})
+        MOCK_HEX = 'mock hex'
+        MOCK_SIG = mock({'hex': lambda: MOCK_HEX})
+
+        KEY = 'key to sign'
+
+        when(client).get_current_block().thenReturn(MOCK_BLOCK)
+        when('plasma_cash.client.client.utils').normalize_key(KEY).thenReturn(KEY)
+        when('plasma_cash.client.client').sign(MOCK_HASH, KEY).thenReturn(MOCK_SIG)
+
+        client.submit_block(KEY)
+
+        verify(child_chain).submit_block(MOCK_HEX)
+
+    def test_send_transaction(self, client, child_chain):
+        DUMMY_PREV_BLOCK = 'dummy prev block'
+        DUMMY_UID = 5566
+        DUMMY_AMOUNT = 123
+        DUMMY_NEW_OWNER = 'new owner'
+        DUMMY_NEW_OWNER_ADDR = 'new owner address'
+        DUMMY_KEY = 'key'
+        DUMMY_NORMALIZED_KEY = 'normalized key'
+        MOCK_TX = mock()
+        DUMMY_TX_HEX = 'dummy tx hex'
+        MOCK_ENCODED_TX = mock({'hex': lambda: DUMMY_TX_HEX})
+
+        (when('plasma_cash.client.client.utils')
+            .normalize_address(DUMMY_NEW_OWNER).thenReturn(DUMMY_NEW_OWNER_ADDR))
+        (when('plasma_cash.client.client.utils')
+            .normalize_key(DUMMY_KEY).thenReturn(DUMMY_NORMALIZED_KEY))
+        (when('plasma_cash.client.client').Transaction(
+            DUMMY_PREV_BLOCK, DUMMY_UID, DUMMY_AMOUNT, DUMMY_NEW_OWNER_ADDR
+            ).thenReturn(MOCK_TX))
+
+        # `Transaction` is mocked previously, so use `any` here as a work around
+        (when('plasma_cash.client.client.rlp')
+            .encode(MOCK_TX, any)
+            .thenReturn(MOCK_ENCODED_TX))
+
+        client.send_transaction(
+            DUMMY_PREV_BLOCK,
+            DUMMY_UID,
+            DUMMY_AMOUNT,
+            DUMMY_NEW_OWNER,
+            DUMMY_KEY
+        )
+        verify(MOCK_TX).sign(DUMMY_NORMALIZED_KEY)
+        verify(child_chain).send_transaction(DUMMY_TX_HEX)
+
+    def test_get_current_block(self, child_chain, client):
+        DUMMY_BLOCK = 'dummy block'
+        DUMMY_BLOCK_HEX = 'dummy block hex'
+        DUMMY_DECODED_BLOCK = 'decoded block'
+
+        when(child_chain).get_current_block().thenReturn(DUMMY_BLOCK)
+        (when('plasma_cash.client.client.utils')
+            .decode_hex(DUMMY_BLOCK)
+            .thenReturn(DUMMY_BLOCK_HEX))
+        (when('plasma_cash.client.client.rlp')
+            .decode(DUMMY_BLOCK_HEX, Block)
+            .thenReturn(DUMMY_DECODED_BLOCK))
+
+        assert client.get_current_block() == DUMMY_DECODED_BLOCK

--- a/unit_tests/utils/test_utils.py
+++ b/unit_tests/utils/test_utils.py
@@ -1,0 +1,21 @@
+from plasma_cash.utils.utils import get_sender, sign
+
+
+class TestUtils(object):
+
+    def test_sign(self):
+        hash_val = b'0' * 32
+        key = b'0' * 32
+        sig = (b'\xf6\x12[\x1b\x04\xe6\xdb\xcb\xe5\xd2\x88\xe41\x89J\xb5\x83\x18\x11\xa8'
+               b'A\xed\xfcRK\x9c5i{\xbd\xab|r\xdb\xeeX\x1dp\x9a\xb6\x0e\\<\xa2X\x81\x17\xc5'
+               b'$\xfa\x86i\xe3\xf5\xc0\xd1\xd9d}+\x8f\xceqE\x1c')
+        assert sign(hash_val, key) == sig
+
+    def test_get_sender(self):
+        hash_val = b'0' * 32
+        sig = (b'\xf6\x12[\x1b\x04\xe6\xdb\xcb\xe5\xd2\x88\xe41\x89J\xb5\x83\x18\x11\xa8'
+               b'A\xed\xfcRK\x9c5i{\xbd\xab|r\xdb\xeeX\x1dp\x9a\xb6\x0e\\<\xa2X\x81\x17\xc5'
+               b'$\xfa\x86i\xe3\xf5\xc0\xd1\xd9d}+\x8f\xceqE\x1c')
+
+        expected_sender = b'\x82{D\xd5=\xf2\x85@Wq;%\xcd\xd6S\xebp\xfe6\xc4'
+        assert get_sender(hash_val, sig) == expected_sender


### PR DESCRIPTION
This covers unit tests for everything under client/ and utils/utils.py 
fix #11, #12, #14

Some changes:
- change the name of `ChildChainService` to `ChildChainClient` since it looks more like a client that calls child chain service.
- remove the default values in `Client` constructor, use dependency container if user want lazy setup instance. (updated README)
- remove the default value of currency on Client.deposit, unless there's a reason that we should default that to 0x0000..
