### PR TITLE
raise exception when `block_num` is invalid when `get_block`

### DIFF
--- a/plasma_cash/child_chain/exceptions.py
+++ b/plasma_cash/child_chain/exceptions.py
@@ -16,3 +16,7 @@ class TxAlreadySpentException(Exception):
 
 class TxAmountMismatchException(Exception):
     """tx input total amount is not equal to output total amount"""
+
+
+class InvalidBlockNumException(Exception):
+    """block num does not have related block"""

--- a/plasma_cash/client/client.py
+++ b/plasma_cash/client/client.py
@@ -1,5 +1,4 @@
 import rlp
-
 from ethereum import utils
 from web3.auto import w3
 

--- a/unit_tests/child_chain/test_child_chain.py
+++ b/unit_tests/child_chain/test_child_chain.py
@@ -1,12 +1,14 @@
+from threading import Thread
+
 import pytest
 import rlp
 from ethereum import utils as eth_utils
 from mockito import ANY, expect, mock, verify, when
-from threading import Thread
 
 from plasma_cash.child_chain.block import Block
 from plasma_cash.child_chain.child_chain import ChildChain
-from plasma_cash.child_chain.exceptions import (InvalidBlockSignatureException,
+from plasma_cash.child_chain.exceptions import (InvalidBlockNumException,
+                                                InvalidBlockSignatureException,
                                                 InvalidTxSignatureException,
                                                 PreviousTxNotFoundException,
                                                 TxAlreadySpentException,
@@ -164,6 +166,15 @@ class TestChildChain(UnstubMixin):
 
         expected = rlp.encode(child_chain.db.get_block(DUMMY_BLK_NUM)).hex()
         assert expected == child_chain.get_block(DUMMY_BLK_NUM)
+
+    def test_get_non_existing_block_would_fail(self, child_chain):
+        NON_EXISTING_BLOCK_NUM = 10000
+        with pytest.raises(InvalidBlockNumException):
+            child_chain.get_block(NON_EXISTING_BLOCK_NUM)
+
+    def test_get_block_with_less_than_1_would_fail(self, child_chain):
+        with pytest.raises(InvalidBlockNumException):
+            child_chain.get_block(0)
 
     def test_get_proof(self, child_chain):
         DUMMY_BLK_NUM = 1


### PR DESCRIPTION
- current `get_block` would fail at db level when `block_num` is invalid.
- if it's asking current block, would fail to response. (However, might worth discuss that should `get_block` return not stabilized block???)