### PR TITLE
operator-client bi-direction event system in WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ python deployment.py
 
 Run child chain:
 ```
-FLASK_APP=plasma_cash/child_chain flask run --port=8546
+python -m plasma_cash.child_chain
 ```
 
 Client:

--- a/integration_tests/features/environment.py
+++ b/integration_tests/features/environment.py
@@ -34,8 +34,4 @@ def deploy_contracts():
 
 
 def spin_up_child_chain_server():
-    my_env = os.environ.copy()
-    my_env.update({
-        'FLASK_APP': 'plasma_cash/child_chain'
-    })
-    return Popen(['flask', 'run', '--port=8546'], env=my_env, preexec_fn=os.setsid)
+    return Popen(['python', '-m', 'plasma_cash.child_chain'], preexec_fn=os.setsid, stdout=PIPE)

--- a/plasma_cash/child_chain/__init__.py
+++ b/plasma_cash/child_chain/__init__.py
@@ -1,8 +1,10 @@
 from flask import Flask
+from flask_sockets import Sockets
 
 
 def create_app(is_unit_test=False):
     app = Flask(__name__)
+    sockets = Sockets(app)
 
     if not is_unit_test:
         from plasma_cash.dependency_config import container
@@ -11,5 +13,6 @@ def create_app(is_unit_test=False):
 
     from . import server
     app.register_blueprint(server.bp)
+    sockets.register_blueprint(server.ws)
 
     return app

--- a/plasma_cash/child_chain/__init__.py
+++ b/plasma_cash/child_chain/__init__.py
@@ -1,10 +1,8 @@
 from flask import Flask
-from flask_sockets import Sockets
 
 
 def create_app(is_unit_test=False):
     app = Flask(__name__)
-    sockets = Sockets(app)
 
     if not is_unit_test:
         from plasma_cash.dependency_config import container
@@ -13,6 +11,5 @@ def create_app(is_unit_test=False):
 
     from . import server
     app.register_blueprint(server.bp)
-    sockets.register_blueprint(server.ws)
 
     return app

--- a/plasma_cash/child_chain/__main__.py
+++ b/plasma_cash/child_chain/__main__.py
@@ -1,0 +1,22 @@
+import argparse
+
+from gevent import pywsgi
+from geventwebsocket.handler import WebSocketHandler
+
+from plasma_cash.child_chain import create_app
+
+if __name__ == '__main__':
+    app = create_app()
+
+    parser = argparse.ArgumentParser(prog=__package__)
+    parser.add_argument('--host', default='127.0.0.1', help='Hostname to listen on.')
+    parser.add_argument('--port', default='8546', help='Port number to listen on.')
+    args = parser.parse_args()
+
+    print('Listening on ' + args.host + ':' + args.port)
+    server = pywsgi.WSGIServer((args.host, int(args.port)), app, handler_class=WebSocketHandler)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass

--- a/plasma_cash/child_chain/websocket.py
+++ b/plasma_cash/child_chain/websocket.py
@@ -1,0 +1,27 @@
+import json
+
+callback = {}
+
+
+def on(event):
+    def decorator(func):
+        callback[event] = func
+        return func
+    return decorator
+
+
+def listen(request):
+    ws = request.environ['wsgi.websocket']
+
+    try:
+        while True:
+            data = json.loads(ws.receive())
+            if 'event' not in data or 'arg' not in data or data['event'] not in callback:
+                # Invalid WebSocket request
+                continue
+            callback[data['event']](ws, data['arg'])
+    except TypeError:
+        # Ignore disconnection
+        pass
+
+    return ''

--- a/plasma_cash/dependency_config.py
+++ b/plasma_cash/dependency_config.py
@@ -48,7 +48,10 @@ class DependencyContainer(object):
 
     def get_child_chain_client(self):
         if self._child_chain_client is None:
-            self._child_chain_client = ChildChainClient('http://localhost:8546')
+            self._child_chain_client = ChildChainClient(
+                'http://localhost:8546',
+                'ws://localhost:8546'
+            )
         return self._child_chain_client
 
     def get_client(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 py-solc==2.1.0
 web3==4.2.0
 Flask==1.0.2
-Flask-Sockets==0.2.1
+gevent-websocket==0.10.1
 websocket-client==0.48.0
 requests==2.18.4
 rlp==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 py-solc==2.1.0
 web3==4.2.0
 Flask==1.0.2
+Flask-Sockets==0.2.1
+websocket-client==0.48.0
 requests==2.18.4
 rlp==0.6.0
 ethereum==2.3.1

--- a/unit_tests/client/test_child_chain_client.py
+++ b/unit_tests/client/test_child_chain_client.py
@@ -25,6 +25,34 @@ class TestChildChainClient(UnstubMixin):
         assert c.verify == DUMMY_VERIFY
         assert c.timeout == DUMMY_TIME_OUT
 
+    def test_ws_on_message(self, client):
+        DUMMY_WS = 'ws'
+        DUMMY_EVENT = 'event'
+        DUMMY_ARG = 'arg'
+        DUMMY_MESSAGE = '{"event": "event", "arg": "arg"}'
+
+        handler = mock()
+        when(handler).__call__(DUMMY_ARG).thenReturn(DUMMY_ARG)
+        client.ws_callback[DUMMY_EVENT] = handler
+        client.ws_on_message(DUMMY_WS, DUMMY_MESSAGE)
+        verify(handler).__call__(DUMMY_ARG)
+
+    def test_emit(self, client):
+        DUMMY_EVENT = 'event'
+        DUMMY_ARG = 'arg'
+        DUMMY_MESSAGE = '{"event": "event", "arg": "arg"}'
+
+        when(client.ws).send(any).thenReturn(None)
+        client.emit(DUMMY_EVENT, DUMMY_ARG)
+        verify(client.ws).send(DUMMY_MESSAGE)
+
+    def test_on(self, client):
+        DUMMY_EVENT = 'event'
+        DUMMY_HANDLER = 'handler'
+
+        client.on(DUMMY_EVENT, DUMMY_HANDLER)
+        assert client.ws_callback[DUMMY_EVENT] == DUMMY_HANDLER
+
     def test_request_success(self, client):
         DUMMY_END_POINT = '/end-point'
         DUMMY_METHOD = 'post'

--- a/unit_tests/client/test_child_chain_client.py
+++ b/unit_tests/client/test_child_chain_client.py
@@ -8,17 +8,19 @@ from unit_tests.unstub_mixin import UnstubMixin
 
 class TestChildChainClient(UnstubMixin):
     BASE_URL = 'https://dummy-plasma-cash'
+    WS_URL = 'ws://dummy-plasma-cash'
 
     @pytest.fixture(scope='function')
     def client(self):
-        return ChildChainClient(self.BASE_URL)
+        return ChildChainClient(self.BASE_URL, self.WS_URL)
 
     def test_constructor(self):
         DUMMY_BASE_URL = 'base url'
+        DUMMY_WS_URL = 'ws url'
         DUMMY_VERIFY = True
         DUMMY_TIME_OUT = 100
 
-        c = ChildChainClient(DUMMY_BASE_URL, DUMMY_VERIFY, DUMMY_TIME_OUT)
+        c = ChildChainClient(DUMMY_BASE_URL, DUMMY_WS_URL, DUMMY_VERIFY, DUMMY_TIME_OUT)
         assert c.base_url == DUMMY_BASE_URL
         assert c.verify == DUMMY_VERIFY
         assert c.timeout == DUMMY_TIME_OUT


### PR DESCRIPTION
When sending transactions, the receiver client needs readltime
notifications because it needs to confirm that the history has been
received. And due to the clients may not always have public ip availability,
it's easier to set a persistent connection between the server and a client,
and let the server push notifications to clients.

Now, the child_chain_client connects to the server in its constructor,
and provides `emit`, `on` event system for easier communications.
Also, the client can register its identity, like address, after connecting
to the server, and the server can identify each client to send or relay
messages. For example:

Alice:
```
c = container.get_child_chain_client()
c.emit('join', 'alice')
c.on('relay', print)
```

Bob:
```
c = container.get_child_chain_client()
c.emit('join', 'bob')
c.emit('relay', {'dest': 'alice', 'message': 'hello'})
```

And due to a WebSocket framework was introduced on server side,
the server startup command was changed to
```
python -m plasma_cash.child_chain
```
the orignal `flask run` command will failed to start the WebSocket
service.