### PR TITLE
Block second tx with same uid in same block

### DIFF
--- a/plasma_cash/child_chain/child_chain.py
+++ b/plasma_cash/child_chain/child_chain.py
@@ -13,7 +13,7 @@ from .exceptions import (InvalidBlockNumException,
                          InvalidBlockSignatureException,
                          InvalidTxSignatureException,
                          PreviousTxNotFoundException, TxAlreadySpentException,
-                         TxAmountMismatchException)
+                         TxAmountMismatchException, TxWithSameUidAlreadyExists)
 from .transaction import Transaction
 
 
@@ -76,6 +76,8 @@ class ChildChain(object):
             raise TxAmountMismatchException('failed to apply transaction')
         if tx.sig == b'\x00' * 65 or tx.sender != prev_tx.new_owner:
             raise InvalidTxSignatureException('failed to apply transaction')
+        if self.current_block.get_tx_by_uid(tx.uid):
+            raise TxWithSameUidAlreadyExists('failed to apply transaction')
 
         prev_tx.spent = True  # Mark the previous tx as spent
         self.current_block.add_tx(tx)

--- a/plasma_cash/child_chain/exceptions.py
+++ b/plasma_cash/child_chain/exceptions.py
@@ -20,3 +20,7 @@ class TxAmountMismatchException(Exception):
 
 class InvalidBlockNumException(Exception):
     """block num does not have related block"""
+
+
+class TxWithSameUidAlreadyExists(Exception):
+    """the block already has one tx with the uid"""

--- a/unit_tests/child_chain/test_child_chain.py
+++ b/unit_tests/child_chain/test_child_chain.py
@@ -167,6 +167,11 @@ class TestChildChain(UnstubMixin):
         expected = rlp.encode(child_chain.db.get_block(DUMMY_BLK_NUM)).hex()
         assert expected == child_chain.get_block(DUMMY_BLK_NUM)
 
+    def test_get_block_with_current_block_number(self, child_chain):
+        current_block_number = child_chain.current_block_number
+        expected = rlp.encode(child_chain.current_block).hex()
+        assert expected == child_chain.get_block(current_block_number)
+
     def test_get_non_existing_block_would_fail(self, child_chain):
         NON_EXISTING_BLOCK_NUM = 10000
         with pytest.raises(InvalidBlockNumException):


### PR DESCRIPTION
fix #79 

Since plasma cash uses one sparse merkle tree in one block,
and each uid would occupy one leaf of the tree. One block could
only has one tx with same uid because there could only be one proof.
This commit block the second tx to be included in the block in child chain.