### PR TITLE
Update README for supporting python3.5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install [Node.js](https://nodejs.org/en/download/). Then,
 $ npm install -g ganache-cli
 ```
 
-- [Python 3.2+](https://www.python.org/downloads/)
+- [Python 3.5+](https://www.python.org/downloads/)
 
 ### Develop
 


### PR DESCRIPTION
When setting up env, I found out that web3.py requires python version 3.5+.