### PR TITLE
Change delta from 0.01 to 0.05 for latest ganache

### DIFF
--- a/integration_tests/features/steps/basic_flow.py
+++ b/integration_tests/features/steps/basic_flow.py
@@ -119,4 +119,4 @@ def userB_finalize_exit(context):
 def userB_successfully_exit_from_root_chain_after_exit(context, amount):
     balance = w3.eth.getBalance(userB)
     assert_msg = 'balance: {} is not in around: {}'.format(w3.fromWei(balance, 'ether'), amount)
-    assert w3.toWei(amount - 0.01, 'ether') <= balance <= w3.toWei(amount, 'ether'), assert_msg
+    assert w3.toWei(amount - 0.05, 'ether') <= balance <= w3.toWei(amount, 'ether'), assert_msg


### PR DESCRIPTION
I've update my mac's ganache-cli and is able to reproduce the same error in travis CI.

Seams like latest Ganache (Ganache CLI v6.1.8 (ganache-core: 2.2.1))
would use more gas for transaction. As a result, losen the "delta" for
"around" 101 eth in integration test.