### PR TITLE
Build, sign and send tx instead of using `transact`

### DIFF
--- a/plasma_cash/client/history.py
+++ b/plasma_cash/client/history.py
@@ -1,5 +1,5 @@
 import rlp
-from rlp.sedes import big_endian_int, binary, CountableList
+from rlp.sedes import CountableList, big_endian_int, binary
 
 from .exceptions import TxHistoryNotFoundException
 

--- a/plasma_cash/dependency_config.py
+++ b/plasma_cash/dependency_config.py
@@ -1,9 +1,9 @@
 import os
 
 from plasma_cash.child_chain.child_chain import ChildChain
+from plasma_cash.child_chain.child_chain_client import ChildChainClient
 from plasma_cash.child_chain.db.leveldb import LevelDb
 from plasma_cash.child_chain.db.memory_db import MemoryDb
-from plasma_cash.child_chain.child_chain_client import ChildChainClient
 from plasma_cash.config import PROJECT_DIR, db_config, plasma_config
 from plasma_cash.root_chain.deployer import Deployer
 
@@ -38,10 +38,10 @@ class DependencyContainer(object):
 
     def get_child_chain(self):
         if self._child_chain is None:
-            authority = plasma_config['AUTHORITY']
+            key = plasma_config['AUTHORITY_KEY']
             root_chain = self.get_root_chain()
             db = self.get_db()
-            self._child_chain = ChildChain(authority, root_chain, db)
+            self._child_chain = ChildChain(key, root_chain, db)
         return self._child_chain
 
     def get_child_chain_client(self):

--- a/unit_tests/operator_cron_job/test_main.py
+++ b/unit_tests/operator_cron_job/test_main.py
@@ -26,7 +26,7 @@ class TestMain(UnstubMixin):
 
     def test_setup_job_handler(self, root_chain, child_chain):
         (when('plasma_cash.operator_cron_job.__main__.container')
-            .get_child_chain().thenReturn(child_chain))
+            .get_child_chain_client().thenReturn(child_chain))
 
         (when('plasma_cash.operator_cron_job.__main__.container')
             .get_root_chain().thenReturn(root_chain))


### PR DESCRIPTION
Previously, all our call to smart contract uses web3's `transact` api.
However, that api relies on the eth node to have account information in
its wallet. This is an unwanted feature that we want to remove. Also, this
would block us from using infura (web service), and also parity node would
need another manual action to approve account tx, which make previous code
impossible to use with the two eth nodes. This commit changes `transact` to
`buildTransaction` and then sign and send.

fix #95 