### PR TITLE
Fix short address decoding

### DIFF
--- a/plasma_cash/root_chain/contracts/Libraries/RLP.sol
+++ b/plasma_cash/root_chain/contracts/Libraries/RLP.sol
@@ -129,10 +129,8 @@ library RLP {
         uint rStartPos;
         uint len;
         (rStartPos, len) = _decode(self);
-        require(len == 20);
-        assembly {
-            data := div(mload(rStartPos), exp(256, 12))
-        }
+        require(len <= 20);
+	return address(toUint(self));
     }
 
     /// @dev Return the RLP encoded bytes.

--- a/plasma_cash/root_chain/contracts/Libraries/RLP.sol
+++ b/plasma_cash/root_chain/contracts/Libraries/RLP.sol
@@ -126,11 +126,10 @@ library RLP {
         view
         returns (address data)
     {
-        uint rStartPos;
         uint len;
-        (rStartPos, len) = _decode(self);
+        (, len) = _decode(self);
         require(len <= 20);
-	return address(toUint(self));
+        return address(toUint(self));
     }
 
     /// @dev Return the RLP encoded bytes.


### PR DESCRIPTION
Example addresses:
```
0x0014F55A50b281EFD12294f0Cda821Bd8171e920
0x0000000000000000000000000000000000000000
```