### PR TITLE
prevent overflow in RootChain.sol deposit

### DIFF
--- a/plasma_cash/root_chain/contracts/RootChain/RootChain.sol
+++ b/plasma_cash/root_chain/contracts/RootChain/RootChain.sol
@@ -97,6 +97,8 @@ contract RootChain {
         // TODO: handle the currency address if it's not zero
         if (currency == address(0)) {
             require(amount * 10**18 == msg.value);
+            // check for overflow
+            require(amount * 10**18 / 10**18 == amount);
         }
         uint uid = uint256(keccak256(currency, msg.sender, depositCount));
         wallet[uid] = funds({


### PR DESCRIPTION
Exploit scenario:
user calls `deposit()` with `amount` set as `115792089237316195423570985008687907853269984665640564039458 `but only sends `415992086870360064` wei.

An alternative solution would be to use the SafeMath library. 

I don't have time to do it at the moment, but unit tests for the contracts should be added as well